### PR TITLE
link updated in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python -m SimpleHTTPServer
 [MRMRS](http://mrmrs.cc "Adam Morse - Designer Developer")
 
 # Reference
-[Mozilla HTML element list](http://https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/HTML5_element_list "Mozilla HTML element list")
+[Mozilla HTML element list](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/HTML5_element_list "Mozilla HTML element list")
 
 # MIT LICENSE
 Copyright (c) 2018 Adam Morse http://opensource.org/licenses/MIT


### PR DESCRIPTION
***
##Description
Small issue but in the readme.md the link under the section "Reference" to the Mozilla website is not correctly linked.

***
##Issue
fixed #27 