### PR TITLE
radio input field linking fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,9 +226,10 @@
           <div>
             <label>Radio Buttons</label>
             <ul>
-              <li><label><input type="radio" /> Label 1</label></li>
-              <li><label><input type="radio" /> Label 2</label></li>
-              <li><label><input type="radio" /> Label 3</label></li>
+              <!-- All radio buttons have the same name attribute to ensure they are part of the same group -->
+              <li><label><input type="radio" name="group1" /> Label 1</label></li>
+              <li><label><input type="radio" name="group1" /> Label 2</label></li>
+              <li><label><input type="radio" name="group1" /> Label 3</label></li>
             </ul>
           </div>
 


### PR DESCRIPTION
This update corrects the issue where radio buttons in the form were not properly linked, allowing multiple selections at once. By ensuring all related radio buttons share the same name attribute, they are now grouped correctly, so selecting one will automatically deselect the others.